### PR TITLE
Removed quiet-page layout.

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,9 +3,11 @@ layout: default
 ---
 <article class="post">
 
+  {% if page.title %}
   <header class="post-header">
-    <h1 class="post-title">{{ page.quiet_title | escape }}</h1>
+    <h1 class="post-title">{{ page.title | escape }}</h1>
   </header>
+  {% endif %}
 
   <div class="post-content">
     {{ content }}

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -1,3 +1,7 @@
 ---
 ---
 @import "minima";
+
+.post-content h1 {
+	font-size: 42px;
+}

--- a/index.md
+++ b/index.md
@@ -2,10 +2,12 @@
 # Feel free to add content and custom Front Matter to this file.
 # To modify the layout, see https://jekyllrb.com/docs/themes/#overriding-theme-defaults
 
-layout: quiet-page
+layout: page
 permalink: /
-quiet-title: Home
 ---
+
+# Home
+
 ![Oculus Grandma](/img/OculusGrandma.jpg){:class="img-responsive" style="display:block; margin:auto"}
 
 

--- a/not-ready.md
+++ b/not-ready.md
@@ -1,7 +1,8 @@
 ---
-layout: quiet-page
-quiet_title: Hold Your Horses!
+layout: page
 permalink: /not-ready
 ---
+
+# Hold Your Horses!
 
 This part of the site isn't ready yet - you're going too fast! Come back later.


### PR DESCRIPTION
Noticed we weren't really using it, nor did we need to. Made a few changes
to compensate:

- added CSS rule for `.post-content h1` to bring font-size in line with the
rest of the document.
- changed index.md to not have a title so it doesn't show up in the header
and added an h1 to replace the title.
- made the header rendering in `page.html` conditional to remove some ugly
space that shows up when a page does not have a header.
- updated not-ready.md to use `layout: page` and replaced its title with
an h1